### PR TITLE
reintroduce browserify-shim, revert build for graphiql

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -5,7 +5,6 @@ module.exports = {
     require.resolve('@babel/preset-react'),
   ],
   plugins: [
-    require.resolve('@babel/plugin-proposal-class-properties'),
-    // require.resolve('@babel/plugin-transform-runtime'),
+    require.resolve('@babel/plugin-proposal-class-properties')
   ],
 };

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,3 @@
 [build]
-  command = "yarn install && yarn build && cd packages/graphiql/example && yarn install"
+  command = "yarn install && yarn build && cd packages/graphiql/example && yarn install && yarn setup"
   publish = "packages/graphiql/example"

--- a/package.json
+++ b/package.json
@@ -7,6 +7,13 @@
     "mocha": "--full-trace --require @babel/register --require resources/mochaBootload 'packages/{*,!graphiql}/src/**/__tests__/**/*-test.js'",
     "mocha_tdd": "--full-trace --watch --require resources/mochaBootload packages/*/src/**/__tests__/**/*-test.js"
   },
+  "browserify-shim": {
+    "react": "global:React",
+    "react-dom": "global:ReactDOM"
+  },
+  "browser": {
+    "copy-to-clipboard": "./node-modules/copy-to-clipboard/index.js"
+  },
   "scripts": {
     "build": "lerna run build",
     "test": "yarn run lint && yarn run check && yarn run build && yarn run testonly",

--- a/packages/graphiql/.gitignore
+++ b/packages/graphiql/.gitignore
@@ -2,3 +2,6 @@ dist/
 /graphiql.js
 /graphiql.min.js
 /graphiql.css
+example/yarn.lock
+example/graphiql.js
+example/graphiql.css

--- a/packages/graphiql/example/index.html
+++ b/packages/graphiql/example/index.html
@@ -37,8 +37,8 @@
       copy them directly into your environment, or perhaps include them in your
       favored resource bundler.
      -->
-    <link rel="stylesheet" href="./node_modules/graphiql/graphiql.css" />
-    <script src="./node_modules/graphiql/graphiql.js" charset="utf-8"></script>
+    <link rel="stylesheet" href="/graphiql.css" />
+    <script src="/graphiql.js" charset="utf-8"></script>
 
   </head>
   <body>
@@ -110,7 +110,7 @@
         // When working locally, the example expects a GraphQL server at the path /graphql.
         // In a PR preview, it connects to the Star Wars API externally.
         // Change this to point wherever you host your GraphQL server.
-        const isDev = window.location.hostname === 'localhost'
+        const isDev = !window.location.hostname.match(/(^|\.)netlify\.com$|(^|\.)graphql\.org$/)
         const api = isDev ? '/graphql' : 'https://swapi.graph.cool/'
         return fetch(api, {
           method: 'post',

--- a/packages/graphiql/example/package.json
+++ b/packages/graphiql/example/package.json
@@ -1,6 +1,7 @@
 {
   "description": "An example using GraphiQL",
   "scripts": {
+    "setup": "cp ../graphiql.js ../graphiql.css .",
     "start": "node server.js"
   },
   "dependencies": {

--- a/packages/graphiql/package.json
+++ b/packages/graphiql/package.json
@@ -24,10 +24,6 @@
     "README.md",
     "LICENSE"
   ],
-  "browserify-shim": {
-    "react": "global:React",
-    "react-dom": "global:ReactDOM"
-  },
   "jest": {
     "clearMocks": true,
     "setupFiles": [
@@ -44,10 +40,10 @@
   },
   "scripts": {
     "build": "yarn run build-js && yarn run build-flow",
-    "build-js": "node ../../resources/buildJs.js",
+    "build-js": "bash ./resources/build.sh",
     "build-flow": "node ../../resources/buildFlow.js",
     "check": "flow check",
-    "dev": "babel-node test/server.js",
+    "dev": "babel-node --root-mode upward test/server.js",
     "prepublish": ". ./resources/prepublish.sh",
     "preversion": ". ./resources/checkgit.sh && npm test",
     "test": "jest --no-cache spec"

--- a/packages/graphiql/resources/build.sh
+++ b/packages/graphiql/resources/build.sh
@@ -4,16 +4,16 @@ set -e
 set -o pipefail
 
 if [ ! -d "node_modules/.bin" ]; then
-  echo "Be sure to run \`npm install\` before building GraphiQL."
+  echo "Be sure to run \`yarn install\` before building GraphiQL."
   exit 1
 fi
 
 rm -rf dist/ && mkdir -p dist/
-babel src --ignore __tests__ --out-dir dist/
+babel src --root-mode upward --ignore __tests__ --out-dir dist/
 echo "Bundling graphiql.js..."
-browserify -s GraphiQL dist/index.js > graphiql.js
+browserify -g browserify-shim -s GraphiQL dist/index.js > graphiql.js
 echo "Bundling graphiql.min.js..."
-browserify -t uglifyify -s GraphiQL dist/index.js 2> /dev/null | uglifyjs -c > graphiql.min.js 2> /dev/null
+browserify -g browserify-shim -t uglifyify -s GraphiQL dist/index.js 2> /dev/null | uglifyjs -c > graphiql.min.js 2> /dev/null
 echo "Bundling graphiql.css..."
 postcss --no-map --use autoprefixer -d dist/ css/*.css
 cat dist/*.css > graphiql.css

--- a/packages/graphiql/test/server.js
+++ b/packages/graphiql/test/server.js
@@ -28,7 +28,7 @@ const b = browserify({
   entries: [path.join(__dirname, '../src/index.js')],
   cache: {},
   packageCache: {},
-  transform: [babelify, browserifyShim],
+  transform: [[babelify, { rootMode: 'upward' }], browserifyShim],
   plugin: [watchify],
   standalone: 'GraphiQL',
   globalTransform: 'browserify-shim',


### PR DESCRIPTION
- re-introduce browserify-shim to the graphiql build
- move browserify-shim config to the package.json root so it would pick up commonjs dependencies
- revert graphiql build script to original resources/build.sh to retain parity with existing export patterns and autoprefixing
- ensure netlify example gets published with expected graphiql.js and graphiql.css files