### PR TITLE
feat: use monaco editor in GraphiQL

### DIFF
--- a/packages/monaco-graphql/src/GraphQLWorker.ts
+++ b/packages/monaco-graphql/src/GraphQLWorker.ts
@@ -1,0 +1,122 @@
+/**
+ *  Copyright (c) 2020 GraphQL Contributors.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ */
+
+import type {
+  worker,
+  editor,
+  languages,
+  Position,
+  IRange,
+} from 'monaco-editor';
+
+import {
+  getRange,
+  CompletionItem as GraphQLCompletionItem,
+  LanguageService,
+} from 'graphql-languageservice';
+
+import {
+  toGraphQLPosition,
+  toMonacoRange,
+  toMarkerData,
+  toCompletion,
+} from './utils';
+
+export type MonacoCompletionItem = languages.CompletionItem & {
+  isDeprecated?: boolean;
+  deprecationReason?: string | null;
+};
+
+export class GraphQLWorker {
+  private _ctx: worker.IWorkerContext;
+  private _languageService: LanguageService;
+  constructor(
+    ctx: worker.IWorkerContext,
+    createData: monaco.languages.graphql.ICreateData,
+  ) {
+    this._ctx = ctx;
+    this._languageService = new LanguageService({ uri: createData.schemaUrl });
+  }
+  async getSchema() {
+    return this._languageService.getSchema();
+  }
+  async doValidation(uri: string): Promise<editor.IMarkerData[]> {
+    const document = this._getTextDocument(uri);
+    const graphqlDiagnostics = await this._languageService.getDiagnostics(
+      uri,
+      document,
+    );
+    return graphqlDiagnostics.map(toMarkerData);
+  }
+
+  async doComplete(
+    uri: string,
+    position: Position,
+  ): Promise<(GraphQLCompletionItem & { range: IRange })[]> {
+    const document = this._getTextDocument(uri);
+    const graphQLPosition = toGraphQLPosition(position);
+    const suggestions = await this._languageService.getCompletion(
+      uri,
+      document,
+      graphQLPosition,
+    );
+
+    return suggestions.map(suggestion =>
+      toCompletion(
+        suggestion,
+        getRange(
+          {
+            column: graphQLPosition.character + 1,
+            line: graphQLPosition.line + 1,
+          },
+          document,
+        ),
+      ),
+    );
+  }
+
+  async doHover(uri: string, position: Position) {
+    const document = this._getTextDocument(uri);
+    const graphQLPosition = toGraphQLPosition(position);
+
+    const hover = await this._languageService.getHover(
+      uri,
+      document,
+      graphQLPosition,
+    );
+
+    return {
+      content: hover,
+      range: toMonacoRange(
+        getRange(
+          {
+            column: graphQLPosition.character + 1,
+            line: graphQLPosition.line + 1,
+          },
+          document,
+        ),
+      ),
+    };
+  }
+  async doFormat(text: string): Promise<string> {
+    const prettierStandalone = await import('prettier/standalone');
+    const prettierGraphqlParser = await import('prettier/parser-graphql');
+
+    return prettierStandalone.format(text, {
+      parser: 'graphql',
+      plugins: [prettierGraphqlParser],
+    });
+  }
+
+  private _getTextDocument(_uri: string): string {
+    const models = this._ctx.getMirrorModels();
+    if (models.length > 0) {
+      return models[0].getValue();
+    }
+    return '';
+  }
+}

--- a/packages/monaco-graphql/src/graphql.worker.ts
+++ b/packages/monaco-graphql/src/graphql.worker.ts
@@ -5,138 +5,20 @@
  *  LICENSE file in the root directory of this source tree.
  */
 
-import * as monaco from 'monaco-editor';
+import { worker as WorkerNamespace } from 'monaco-editor';
 // @ts-ignore
 import * as worker from 'monaco-editor/esm/vs/editor/editor.worker';
-import { Range as GraphQLRange } from 'graphql-language-service-types';
 
-export interface ICreateData {
-  languageId: string;
-  enableSchemaRequest: boolean;
-  schemaUrl: string;
-}
-
-import {
-  getRange,
-  CompletionItem as GraphQLCompletionItem,
-  LanguageService,
-} from 'graphql-languageservice';
-
-import { toGraphQLPosition, toMonacoRange, toMarkerData } from './utils';
-
-export type MonacoCompletionItem = monaco.languages.CompletionItem & {
-  isDeprecated?: boolean;
-  deprecationReason?: string | null;
-};
-
-export function toCompletion(
-  entry: GraphQLCompletionItem,
-  range: GraphQLRange,
-): GraphQLCompletionItem & { range: monaco.IRange } {
-  return {
-    label: entry.label,
-    insertText: entry.insertText || (entry.label as string),
-    sortText: entry.sortText,
-    filterText: entry.filterText,
-    documentation: entry.documentation,
-    detail: entry.detail,
-    range: toMonacoRange(range),
-    kind: entry.kind,
-  };
-}
-
-export class GraphQLWorker {
-  private _ctx: monaco.worker.IWorkerContext;
-  private _languageService: LanguageService;
-  constructor(ctx: monaco.worker.IWorkerContext, createData: ICreateData) {
-    this._ctx = ctx;
-    this._languageService = new LanguageService({ uri: createData.schemaUrl });
-  }
-  async getSchema() {
-    return this._languageService.getSchema();
-  }
-  async doValidation(uri: string): Promise<monaco.editor.IMarkerData[]> {
-    const document = this._getTextDocument(uri);
-    const graphqlDiagnostics = await this._languageService.getDiagnostics(
-      uri,
-      document,
-    );
-    return graphqlDiagnostics.map(toMarkerData);
-  }
-
-  async doComplete(
-    uri: string,
-    position: monaco.Position,
-  ): Promise<(GraphQLCompletionItem & { range: monaco.IRange })[]> {
-    const document = this._getTextDocument(uri);
-    const graphQLPosition = toGraphQLPosition(position);
-    const suggestions = await this._languageService.getCompletion(
-      uri,
-      document,
-      graphQLPosition,
-    );
-
-    return suggestions.map(suggestion =>
-      toCompletion(
-        suggestion,
-        getRange(
-          {
-            column: graphQLPosition.character + 1,
-            line: graphQLPosition.line + 1,
-          },
-          document,
-        ),
-      ),
-    );
-  }
-
-  async doHover(uri: string, position: monaco.Position) {
-    const document = this._getTextDocument(uri);
-    const graphQLPosition = toGraphQLPosition(position);
-
-    const hover = await this._languageService.getHover(
-      uri,
-      document,
-      graphQLPosition,
-    );
-
-    return {
-      content: hover,
-      range: toMonacoRange(
-        getRange(
-          {
-            column: graphQLPosition.character + 1,
-            line: graphQLPosition.line + 1,
-          },
-          document,
-        ),
-      ),
-    };
-  }
-  async doFormat(text: string): Promise<string> {
-    const prettierStandalone = await import('prettier/standalone');
-    const prettierGraphqlParser = await import('prettier/parser-graphql');
-
-    return prettierStandalone.format(text, {
-      parser: 'graphql',
-      plugins: [prettierGraphqlParser],
-    });
-  }
-
-  private _getTextDocument(_uri: string): string {
-    const models = this._ctx.getMirrorModels();
-    if (models.length > 0) {
-      return models[0].getValue();
-    }
-    return '';
-  }
-}
+import { GraphQLWorker } from './GraphQLWorker';
 
 self.onmessage = () => {
   try {
     // ignore the first message
     worker.initialize(
-      (ctx: monaco.worker.IWorkerContext, createData: ICreateData) => {
+      (
+        ctx: WorkerNamespace.IWorkerContext,
+        createData: monaco.languages.graphql.ICreateData,
+      ) => {
         return new GraphQLWorker(ctx, createData);
       },
     );

--- a/packages/monaco-graphql/src/graphqlMode.ts
+++ b/packages/monaco-graphql/src/graphqlMode.ts
@@ -10,7 +10,7 @@ import * as monaco from 'monaco-editor';
 import IRichLanguageConfiguration = monaco.languages.LanguageConfiguration;
 
 import { WorkerManager } from './workerManager';
-import { GraphQLWorker } from './graphql.worker';
+import { GraphQLWorker } from './GraphQLWorker';
 import { monarchLanguage } from './monaco.contribution';
 import { LanguageServiceDefaultsImpl } from './defaults';
 import * as languageFeatures from './languageFeatures';

--- a/packages/monaco-graphql/src/languageFeatures.ts
+++ b/packages/monaco-graphql/src/languageFeatures.ts
@@ -5,7 +5,7 @@
  *  LICENSE file in the root directory of this source tree.
  */
 
-import { GraphQLWorker } from './graphql.worker';
+import { GraphQLWorker } from './GraphQLWorker';
 import { LanguageServiceDefaultsImpl } from './defaults';
 
 import {

--- a/packages/monaco-graphql/src/typings/monaco.d.ts
+++ b/packages/monaco-graphql/src/typings/monaco.d.ts
@@ -4,6 +4,7 @@
  *  This source code is licensed under the MIT license found in the
  *  LICENSE file in the root directory of this source tree.
  */
+
 declare module monaco.languages.graphql {
   export interface IDisposable {
     dispose(): void;
@@ -99,6 +100,12 @@ declare module monaco.languages.graphql {
      * Defines whether the built-in selection range provider is enabled.
      */
     readonly selectionRanges?: boolean;
+  }
+
+  export interface ICreateData {
+    languageId: string;
+    enableSchemaRequest: boolean;
+    schemaUrl: string;
   }
 
   export interface LanguageServiceDefaults {

--- a/packages/monaco-graphql/src/workerManager.ts
+++ b/packages/monaco-graphql/src/workerManager.ts
@@ -7,7 +7,7 @@
 
 import * as monaco from 'monaco-editor';
 import { LanguageServiceDefaultsImpl } from './defaults';
-import { GraphQLWorker } from './graphql.worker';
+import { GraphQLWorker } from './GraphQLWorker';
 
 import IDisposable = monaco.IDisposable;
 import Uri = monaco.Uri;


### PR DESCRIPTION
- [x] - move monaco worker to seperate worker file
- [ ] - switch variables/results codemirror with simple `use-monaco` loader for refs, state, etc. using default monaco json mode
- [ ] - switch operation editor to use monaco graphql mode
- [ ] - load schema from monaco worker for SchemaProvider